### PR TITLE
Only use double-quotes if necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -2915,38 +2915,22 @@ condition](#safe-assignment-in-condition).
   ```
 
 * <a name="consistent-string-literals"></a>
-  Adopt a consistent string literal quoting style. There are two popular
-  styles in the Ruby community, both of which are considered good - single
-  quotes by default (Option A) and double quotes by default (Option B).
-<sup>[[link](#consistent-string-literals)]</sup>
-
-  * **(Option A)** Prefer single-quoted strings when you don't need
+  Prefer single-quoted strings when you don't need
     string interpolation or special symbols such as `\t`, `\n`, `'`,
     etc.
+<sup>[[link](#consistent-string-literals)]</sup>
+
 
     ```Ruby
     # bad
-    name = "Bozhidar"
+    name = "Kramer"
 
     # good
-    name = 'Bozhidar'
+    name = 'Kramer'
+
+    # fine
+    name = "Kramer's jacket"
     ```
-
-  * **(Option B)** Prefer double-quotes unless your string literal
-    contains `"` or escape characters you want to suppress.
-
-    ```Ruby
-    # bad
-    name = 'Bozhidar'
-
-    # good
-    name = "Bozhidar"
-    ```
-
-  The second style is arguably a bit more popular in the Ruby
-  community. The string literals in this guide, however, are
-  aligned with the first style.
-
 * <a name="no-character-literals"></a>
   Don't use the character literal syntax `?x`. Since Ruby 1.9 it's basically
   redundant - `?x` would interpreted as `'x'` (a string with a single character


### PR DESCRIPTION
We have super inconsistent usage of single and double quoted strings throughout both our Ruby and Javascript. This just deals with Ruby, but figured I'd point that out too.

This should make you cringe:

``` ruby
it 'renders form errors' do
  expect(page).to have_css("#super-bad-errors")
end
```

I'm of the belief that you should use only use double quotes (`"`) if you need their functionality: string interpolation, using single-quotes, special characters.

It would be great to get the whole app to use one style or the other, so long as it's consistent. 
