### PR TITLE
Disambiguate brace spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,36 +202,25 @@ style guide.
 
   `{` and `}` deserve a bit of clarification, since they are used
   for block and hash literals, as well as embedded expressions in
-  strings. For hash literals two styles are considered acceptable.
+  strings. Use spaces inside them when they are used for block and hash literals:
 
   ```Ruby
+  # bad - no space after { or before }
+  {one: 1, two: 2}
+
   # good - space after { and before }
   { one: 1, two: 2 }
-
-  # good - no space after { and before }
-  {one: 1, two: 2}
   ```
 
-  The first variant is slightly more readable (and arguably more
-  popular in the Ruby community in general). The second variant has
-  the advantage of adding visual difference between block and hash
-  literals. Whichever one you pick - apply it consistently.
-
-  As far as embedded expressions go, there are also two acceptable
-  options:
+  Do not use spaces inside `{` and `}` used in embedded expressions:
 
   ```Ruby
+  # bad - spaces
+  "string#{ expr }"
+
   # good - no spaces
   "string#{expr}"
-
-  # ok - arguably more readable
-  "string#{ expr }"
   ```
-
-  The first style is extremely more popular and you're generally
-  advised to stick with it. The second, on the other hand, is
-  (arguably) a bit more readable. As with hashes - pick one style
-  and apply it consistently.
 
 * <a name="no-spaces-braces"></a>
   No spaces after `(`, `[` or before `]`, `)`.


### PR DESCRIPTION
Pick one rule as to whether or not to use spaces inside {} for each way that Ruby uses braces.

At present some people do and some do not put spaces inside braces used for blocks or hash literals.
We should have a single rule that can be followed by automated formatters (which means not treating block and hash literals differently.)

I don't think anyone uses or wants spaces inside #{}, so let's just remove that ambiguity.
### tl;dr of proposed changes
- `ary.each { |x| x.do_thingy }` good; `ary.each {|x| x.do_thingy}` bad
- `"this is a #{adjective} string"` good; `"this is a #{ adjective } string"` bad

Spaces around brackets when used as a hash or block, no spaces when used for interpolation.

To see the changes in context, search for "deserve a bit of clarification" in https://github.com/IndieGoGo/ruby-style-guide/tree/schwa/disambiguate-brace-spacing.
